### PR TITLE
Update `get-issues-and-prs.py` script.

### DIFF
--- a/get-issues-and-prs.py
+++ b/get-issues-and-prs.py
@@ -76,6 +76,10 @@ def get_prs(project):
     return json.loads(output)
 
 
+def print_item(item):
+    print(f'{" "*8}- [ ] [{item["title"]}]({item["url"]})')
+
+
 def main():
     args = parse_args()
     if args.repos is None:
@@ -100,13 +104,12 @@ def main():
         if issues:
             print('    - Issues:')
             for issue in issues:
-                print('        - [ ] [%s](%s)' % (issue['title'],
-                                                  issue['url']))
+                print_item(issue)
 
         if prs:
             print('    - PRs:')
             for pr in prs:
-                print('        - [ ] [%s](%s)' % (pr['title'], pr['url']))
+                print_item(pr)
 
 
 if __name__ == '__main__':

--- a/get-issues-and-prs.py
+++ b/get-issues-and-prs.py
@@ -6,19 +6,13 @@ import subprocess
 from datetime import datetime, timedelta
 
 DEFAULT_OWNER = 'areaDetector'
-DEFAULT_REPOS = [
-    'areaDetector', 'ADCore', 'ADEiger', 'ADAravis', 'ADGenICam',
-    'ADSpinnaker', 'ADVimba', 'ADAndor3', 'ADAndor', 'ADSimDetector',
-    'specsAnalyser', 'ADPylon', 'pvaDriver', 'ADPvCam', 'ADSupport', 'ADUVC',
-    'ADBitFlow', 'ADLambda', 'ADProsilica', 'ADPluginBar', 'ffmpegServer',
-    'ADCompVision', 'ADViewers', 'ADQImaging', 'ADPICam', 'ADCSimDetector',
-    'NDDriverStdArrays', 'ADSBIG', 'ADPSL', 'ADSBIG', 'ADPerkinElmer',
-    'ADLightField', 'ADFireWireWin', 'ADDexela', 'ADPilatus', 'ADMythen',
-    'ADmar345', 'ADRIXSCam', 'ADURL', 'ADmarCCD', 'ADPointGrey', 'ADFastCCD',
-    'ADPixirad', 'ADPcoWin', 'ADPhotron', 'ADPluginCentroids', 'ADADSC',
-    'ADBruker', 'ADPhotonII', 'ADRoper', 'ADnED', 'ADPluginEdge', 'ADPCO',
-    'ADMerlin', 'ADMMPAD', 'ADCameralink', 'ADTimePix', 'firewireDCAM',
-    'ADBinaries', 'ffmpegViewer', 'ADExample'
+DEFAULT_SKIP_REPOS = [
+    'ADKinetix', # has disabled issues
+]
+DEFAULT_FIRST_REPOS = [
+    'areaDetector',
+    'ADCore',
+    'ADSupport',
 ]
 DEFAULT_MAX_DAYS_OLD = 31
 
@@ -26,7 +20,10 @@ DEFAULT_MAX_DAYS_OLD = 31
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--owner', default=DEFAULT_OWNER)
-    parser.add_argument('--repos', nargs='+', default=DEFAULT_REPOS)
+    parser.add_argument('--repos', nargs='+', default=None)
+    parser.add_argument('--skip-repos', nargs='+', default=DEFAULT_SKIP_REPOS)
+    parser.add_argument('--first-repos', nargs='+', default=DEFAULT_FIRST_REPOS)
+    parser.add_argument('--no-skip-archived', action='store_false', dest='skip_archived')
     parser.add_argument('--days', type=int, default=DEFAULT_MAX_DAYS_OLD)
     return parser.parse_args()
 
@@ -39,6 +36,30 @@ def filter_old(items, days):
     now = datetime.now()
     return [item for item in items
             if now - parse_time(item['updatedAt']) <= timedelta(days=days)]
+
+
+def get_repos(owner, skip_archived):
+    command = ['gh', 'repo', 'list', '--limit', '1000', '--json', 'name']
+    if skip_archived:
+        command += ['--no-archived']
+    command += [owner]
+    output = subprocess.check_output(command)
+    repos = json.loads(output)
+    return [repo['name'] for repo in repos]
+
+
+def sort_repos(repos, first_repos):
+    repos_set = set(repos)
+    first_repos_set = set(first_repos)
+
+    # sort repositories after first_repos
+    repos = list(repos_set - first_repos_set)
+    repos.sort()
+
+    # only include first_repos that were in the main list
+    first_repos = [repo for repo in first_repos if repo in repos_set]
+
+    return first_repos + repos
 
 
 def get_issues(project):
@@ -57,7 +78,16 @@ def get_prs(project):
 
 def main():
     args = parse_args()
-    for repo in args.repos:
+    if args.repos is None:
+        repos = get_repos(args.owner, skip_archived=args.skip_archived)
+    else:
+        repos = args.repos
+
+    repos = sort_repos(repos, args.first_repos)
+
+    for repo in repos:
+        if repo in args.skip_repos:
+            continue
         project = f'{args.owner}/{repo}'
         issues = get_issues(project)
         issues = filter_old(issues, args.days)


### PR DESCRIPTION
It was missing some repositories, so stop hardcoding those.

Make it capable of listing stale issues and PRs as well.

Sample output:

```md
- areaDetector:
    - PRs:
        - [ ] [Add ADPimega as a submodule (branch: lumentum-v3)](https://github.com/areaDetector/areaDetector/pull/95)
- ADCore:
    - Issues:
        - [ ] [Out of bounds read/type confusion in compressed arrays with NDPluginStdArrays, can cause segmentation fault](https://github.com/areaDetector/ADCore/issues/531)
        - [ ] [Convert NDPluginPva to use PVXS](https://github.com/areaDetector/ADCore/issues/528)
    - PRs:
        - [ ] [Convert NDPluginPva to use PVXS](https://github.com/areaDetector/ADCore/pull/532)
- ADEiger:
    - Issues:
        - [ ] [The lz4 data in Stream2 is different from Stream](https://github.com/areaDetector/ADEiger/issues/69)
        - [ ] [Driver is copying data twice for each frame in Stream mode, not efficient](https://github.com/areaDetector/ADEiger/issues/68)
        - [ ] [Support Stream2 CBOR format and multiple threshold frames](https://github.com/areaDetector/ADEiger/issues/65)
- ADLambda:
    - Issues:
        - [ ] [Probable bug in driver](https://github.com/areaDetector/ADLambda/issues/13)
- ADPICam:
    - PRs:
        - [ ] [Implement pulse parameters and re-populate enums after a parameter is marked as existing](https://github.com/areaDetector/ADPICam/pull/26)
- ADPcoWin:
    - Issues:
        - [ ] [Linux support?](https://github.com/areaDetector/ADPcoWin/issues/24)
- ADPilatus:
    - PRs:
        - [ ] [Check for 7 OK message when waiting for an image to actualy end the acquisition](https://github.com/areaDetector/ADPilatus/pull/17)
- Stale Items:
    - Stale Issues:
        - [ ] [HDF5 plugin feature where datasets with type=constant is broken](https://github.com/areaDetector/ADCore/issues/36)
        - [ ] [Find a way to stop misbehaving plugins from slowing down driver](https://github.com/areaDetector/ADCore/issues/98)
        - [ ] [HDF5 NDAttribute datasets to support "extra" dimensions like detector datasets](https://github.com/areaDetector/ADCore/issues/96)
        - [ ] [Expand CI services to cover more configurations](https://github.com/areaDetector/ADCore/issues/115)
        - [ ] [option to not write NDAttr* attributes in HDF5 dataset](https://github.com/areaDetector/ADCore/issues/145)
        - [ ] [MEDM slider behaves badly on some Windows systems](https://github.com/areaDetector/ADPhotron/issues/6)
        - [ ] [Allow use of the 2nd ethernet port of the SA-Z for data transfer](https://github.com/areaDetector/ADPhotron/issues/7)
    - Stale PRs:
        - [ ] [prosilica.cpp:](https://github.com/areaDetector/ADProsilica/pull/4)
        - [ ] [Added new prosilica resend params and rates for packet counts](https://github.com/areaDetector/ADProsilica/pull/7)
        - [ ] [Added driver support for NDBitsPerPixel and NDBytesPerPixel parameters](https://github.com/areaDetector/ADProsilica/pull/8)
        - [ ] [Added redef of Gain in prosilica.template so we can set driver limits](https://github.com/areaDetector/ADProsilica/pull/5)
        - [ ] [FIX: call start() after NDEdgePlugin object is created for plugin to work for ADCore >= 2.5,  don't process plugin if input NDArray dimension > 2 (i.e. for Color modes)](https://github.com/areaDetector/ADPluginEdge/pull/3)
        - [ ] [Slac edl](https://github.com/areaDetector/ADCore/pull/316)
        - [ ] [Applied bitsPerPixel.patch to bring in bitsPerPixel support from pcds…](https://github.com/areaDetector/ADCore/pull/314)
```